### PR TITLE
Add DNS rewrite tool on Cloudflare

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+.svelte-kit
+build
+.output
+.wrangler

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,8 @@ pnpm-lock.yaml
 yarn.lock
 bun.lock
 bun.lockb
+node_modules
+.svelte-kit
+build
+.output
+.wrangler

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
 
+## DNS record tool
+
+This app stores DNS records in a Cloudflare D1 database and exposes them as
+AdGuard filter rules. Generated rules are written to an R2 bucket. The following
+record types are supported:
+
+* `A`, `AAAA`, `CNAME`, `HTTPS`, `MX`, `PTR`, `SRV`, and `TXT`.
+
+Rules are emitted in the form `hostname$dnsrewrite=NOERROR;TYPE;VALUE`. For
+`HTTPS` records you may supply additional parameters such as `alpn`, `port` and
+`ipv4hint` as supported by AdGuard.
+
+Example rules:
+
+```
+ha.oandc.fun$dnsrewrite=NOERROR;A;172.20.20.2
+ha.oandc.fun$dnsrewrite=NOERROR;HTTPS;32 . alpn=h3 ipv4hint=172.20.20.2
+```
+
 ## Creating a project
 
 If you're seeing this, you've probably already done this step. Congrats!

--- a/src/lib/server/adblock.ts
+++ b/src/lib/server/adblock.ts
@@ -1,0 +1,8 @@
+import type { InferModel } from 'drizzle-orm';
+import { dnsRecords } from './db/schema';
+
+export type DNSRecord = InferModel<typeof dnsRecords>;
+
+export function toFilter(record: DNSRecord): string {
+       return `${record.name}$dnsrewrite=NOERROR;${record.type};${record.value}`;
+}

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,10 +1,9 @@
-import { drizzle } from 'drizzle-orm/libsql';
-import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/d1';
 import * as schema from './schema';
 import { env } from '$env/dynamic/private';
 
-if (!env.DATABASE_URL) throw new Error('DATABASE_URL is not set');
+if (!env.DB) {
+       throw new Error('DB binding is not available');
+}
 
-const client = createClient({ url: env.DATABASE_URL });
-
-export const db = drizzle(client, { schema });
+export const db = drizzle(env.DB, { schema });

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,6 +1,8 @@
-import { sqliteTable, integer } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
 
-export const user = sqliteTable('user', {
-	id: integer('id').primaryKey(),
-	age: integer('age')
+export const dnsRecords = sqliteTable('dns_records', {
+       id: integer('id').primaryKey({ autoIncrement: true }),
+       name: text('name').notNull(),
+       type: text('type').notNull(),
+       value: text('value').notNull()
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,56 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+       import { onMount } from 'svelte';
+
+       interface Record {
+               id: number;
+               name: string;
+               type: string;
+               value: string;
+       }
+
+       let records: Record[] = [];
+       let name = '';
+       let type = 'A';
+       let value = '';
+
+       async function load() {
+               const res = await fetch('/api/records');
+               records = await res.json();
+       }
+
+       async function create() {
+               await fetch('/api/records', {
+                       method: 'POST',
+                       headers: { 'content-type': 'application/json' },
+                       body: JSON.stringify({ name, type, value })
+               });
+               name = '';
+               value = '';
+               await load();
+       }
+
+       onMount(load);
+</script>
+
+<h1 class="text-2xl font-bold mb-4">DNS Records</h1>
+<form on:submit|preventDefault={create} class="space-y-2">
+       <input class="border p-1" bind:value={name} placeholder="hostname" />
+       <select class="border p-1" bind:value={type}>
+               <option>A</option>
+               <option>AAAA</option>
+               <option>CNAME</option>
+               <option>HTTPS</option>
+               <option>MX</option>
+               <option>PTR</option>
+               <option>SRV</option>
+               <option>TXT</option>
+       </select>
+       <input class="border p-1" bind:value={value} placeholder="value" />
+       <button class="bg-blue-500 text-white px-2 py-1">Add</button>
+</form>
+
+<ul class="mt-4 space-y-1">
+       {#each records as r (r.id)}
+               <li>{r.name} {r.type} {r.value}</li>
+       {/each}
+</ul>

--- a/src/routes/api/records/+server.ts
+++ b/src/routes/api/records/+server.ts
@@ -1,0 +1,18 @@
+import { json } from '@sveltejs/kit';
+import { db } from '$lib/server/db';
+import { dnsRecords } from '$lib/server/db/schema';
+
+export async function GET() {
+       const records = await db.select().from(dnsRecords).all();
+       return json(records);
+}
+
+export async function POST({ request }) {
+       const data = await request.json();
+       await db.insert(dnsRecords).values({
+               name: data.name,
+               type: data.type,
+               value: data.value
+       });
+       return new Response(null, { status: 201 });
+}

--- a/src/routes/filter.txt/+server.ts
+++ b/src/routes/filter.txt/+server.ts
@@ -1,0 +1,13 @@
+import { db } from '$lib/server/db';
+import { dnsRecords } from '$lib/server/db/schema';
+import { toFilter } from '$lib/server/adblock';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ platform }) => {
+       const records = await db.select().from(dnsRecords).all();
+       const content = records.map(toFilter).join('\n');
+       await platform.env.BUCKET.put('filter.txt', content);
+       return new Response(content, {
+               headers: { 'content-type': 'text/plain' }
+       });
+};

--- a/src/worker-configuration.d.ts
+++ b/src/worker-configuration.d.ts
@@ -3,8 +3,10 @@
 // Runtime types generated with workerd@1.20250604.0 2025-06-13 
 declare namespace Cloudflare {
 	interface Env {
-		ASSETS: Fetcher;
-	}
+               ASSETS: Fetcher;
+               DB: D1Database;
+               BUCKET: R2Bucket;
+       }
 }
 interface Env extends Cloudflare.Env {}
 
@@ -5151,6 +5153,9 @@ declare namespace Rpc {
 }
 declare namespace Cloudflare {
     interface Env {
+        ASSETS: Fetcher;
+        DB: D1Database;
+        BUCKET: R2Bucket;
     }
 }
 declare module 'cloudflare:workers' {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,10 +11,20 @@
 		"binding": "ASSETS",
 		"directory": ".svelte-kit/cloudflare"
 	},
-	"observability": {
-		"enabled": true
-	}
-	/**
+        "observability": {
+                "enabled": true
+        },
+        "d1_databases": [
+                {
+                        "binding": "DB",
+                        "database_name": "dns",
+                        "database_id": "00000000-0000-0000-0000-000000000000"
+                }
+        ],
+        "r2_buckets": [
+                { "binding": "BUCKET", "bucket_name": "adblock-output" }
+        ]
+        /**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
 	 */


### PR DESCRIPTION
## Summary
- configure D1 and R2 bindings
- define DNS record schema and database connection
- add API for managing DNS records
- expose filter.txt route storing to R2
- basic Svelte page to add records
- document supported record types

## Testing
- `npx eslint .`
- `npm run lint` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcb47de008325b2916146944c638e