### PR TITLE
Add drizzle migrations and server hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This app stores DNS records in a Cloudflare D1 database and exposes them as
 AdGuard filter rules. Generated rules are written to an R2 bucket. The following
 record types are supported:
 
-* `A`, `AAAA`, `CNAME`, `HTTPS`, `MX`, `PTR`, `SRV`, and `TXT`.
+- `A`, `AAAA`, `CNAME`, `HTTPS`, `MX`, `PTR`, `SRV`, and `TXT`.
 
 Rules are emitted in the form `hostname$dnsrewrite=NOERROR;TYPE;VALUE`. For
 `HTTPS` records you may supply additional parameters such as `alpn`, `port` and
@@ -20,6 +20,18 @@ Example rules:
 ha.oandc.fun$dnsrewrite=NOERROR;A;172.20.20.2
 ha.oandc.fun$dnsrewrite=NOERROR;HTTPS;32 . alpn=h3 ipv4hint=172.20.20.2
 ```
+
+## Database setup
+
+Migrations are stored in `drizzle/migrations`. Generate a migration and apply it
+to your Cloudflare D1 database:
+
+```bash
+pnpm dlx drizzle-kit generate
+wrangler d1 migrations apply agh-dns-records
+```
+
+This creates the required `dns_records` table so the app can run without errors.
 
 ## Creating a project
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -4,6 +4,7 @@ if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is not set');
 
 export default defineConfig({
 	schema: './src/lib/server/db/schema.ts',
+	out: './drizzle/migrations',
 	dialect: 'sqlite',
 	dbCredentials: { url: process.env.DATABASE_URL },
 	verbose: true,

--- a/drizzle/migrations/0000_plain_psylocke.sql
+++ b/drizzle/migrations/0000_plain_psylocke.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `dns_records` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`value` text NOT NULL
+);

--- a/drizzle/migrations/meta/0000_snapshot.json
+++ b/drizzle/migrations/meta/0000_snapshot.json
@@ -1,0 +1,56 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "219d170e-81b9-44d8-87dd-4b9561ea3821",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"tables": {
+		"dns_records": {
+			"name": "dns_records",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1751446598718,
+			"tag": "0000_plain_psylocke",
+			"breakpoints": true
+		}
+	]
+}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,14 @@
+import type { Handle } from '@sveltejs/kit';
+import { getDB } from '$lib/server/db';
+import { migrate } from 'drizzle-orm/d1/migrator';
+
+let migrated = false;
+
+export const handle: Handle = async ({ event, resolve }) => {
+	if (!migrated) {
+		const db = getDB(event.platform);
+		await migrate(db, { migrationsFolder: './drizzle/migrations' });
+		migrated = true;
+	}
+	return resolve(event);
+};


### PR DESCRIPTION
## Summary
- generate Drizzle migration files under `drizzle/migrations`
- configure Drizzle to output migrations where Wrangler expects them
- run migrations automatically from a new `hooks.server.ts`
- document how to apply migrations with Wrangler

## Testing
- `pnpm lint` *(fails: Code style issues found)*
- `pnpm check` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864f34236808325bbcdb0484799cfdc