### PR TITLE
Enable multiple DNS filter lists

### DIFF
--- a/drizzle/migrations/0001_add_filter_lists.sql
+++ b/drizzle/migrations/0001_add_filter_lists.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "filter_lists" (
+    "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "slug" text NOT NULL UNIQUE
+);
+
+INSERT INTO "filter_lists" ("id", "slug") VALUES (1, 'default');
+
+ALTER TABLE "dns_records" ADD COLUMN "list_id" integer NOT NULL DEFAULT 1 REFERENCES filter_lists(id);

--- a/src/lib/server/adblock.ts
+++ b/src/lib/server/adblock.ts
@@ -4,5 +4,30 @@ import { dnsRecords } from './db/schema';
 export type DNSRecord = InferModel<typeof dnsRecords>;
 
 export function toFilter(record: DNSRecord): string {
-       return `${record.name}$dnsrewrite=NOERROR;${record.type};${record.value}`;
+	return `${record.name}$dnsrewrite=NOERROR;${record.type};${record.value}`;
+}
+
+export function generateFilter(records: DNSRecord[]): string {
+	const groups = new Map<string, DNSRecord[]>();
+	for (const record of records) {
+		const arr = groups.get(record.name) ?? [];
+		arr.push(record);
+		groups.set(record.name, arr);
+	}
+
+	const lines: string[] = [];
+
+	for (const [name, recs] of groups) {
+		for (const r of recs) {
+			lines.push(toFilter(r));
+		}
+		const types = new Set<string>(recs.map((r) => r.type));
+		types.add('SOA');
+		const exclusions = Array.from(types)
+			.map((t) => `~${t}`)
+			.join('|');
+		lines.push(`||${name}^$dnstype=${exclusions}`);
+	}
+
+	return lines.join('\n');
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,8 +1,16 @@
 import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
 
+export const filterLists = sqliteTable('filter_lists', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	slug: text('slug').notNull().unique()
+});
+
 export const dnsRecords = sqliteTable('dns_records', {
-       id: integer('id').primaryKey({ autoIncrement: true }),
-       name: text('name').notNull(),
-       type: text('type').notNull(),
-       value: text('value').notNull()
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	listId: integer('list_id')
+		.notNull()
+		.references(() => filterLists.id),
+	name: text('name').notNull(),
+	type: text('type').notNull(),
+	value: text('value').notNull()
 });

--- a/src/routes/api/lists/+server.ts
+++ b/src/routes/api/lists/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+import { getDB } from '$lib/server/db';
+import { filterLists } from '$lib/server/db/schema';
+
+export async function GET({ platform }) {
+	const db = getDB(platform);
+	const lists = await db.select().from(filterLists).all();
+	return json(lists);
+}
+
+export async function POST({ request, platform }) {
+	const data = await request.json();
+	if (!data.slug) {
+		return new Response('slug required', { status: 400 });
+	}
+	const db = getDB(platform);
+	await db.insert(filterLists).values({ slug: data.slug });
+	return new Response(null, { status: 201 });
+}

--- a/src/routes/filter/[slug].txt/+server.ts
+++ b/src/routes/filter/[slug].txt/+server.ts
@@ -4,13 +4,15 @@ import { generateFilter } from '$lib/server/adblock';
 import type { RequestHandler } from './$types';
 import { eq } from 'drizzle-orm';
 
-export const GET: RequestHandler = async ({ platform }) => {
+export const GET: RequestHandler = async ({ platform, params }) => {
 	const db = getDB(platform);
-	const [list] = await db.select().from(filterLists).where(eq(filterLists.slug, 'default')).all();
-	if (!list) return new Response('list not found', { status: 404 });
+	const [list] = await db.select().from(filterLists).where(eq(filterLists.slug, params.slug)).all();
+	if (!list) {
+		return new Response('list not found', { status: 404 });
+	}
 	const records = await db.select().from(dnsRecords).where(eq(dnsRecords.listId, list.id)).all();
 	const content = generateFilter(records);
-	await platform?.env?.BUCKET.put('filter.txt', content);
+	await platform?.env?.BUCKET.put(`filter-${params.slug}.txt`, content);
 	return new Response(content, {
 		headers: { 'content-type': 'text/plain' }
 	});


### PR DESCRIPTION
## Summary
- allow records to belong to a filter list
- generate blocking rules for unwanted DNS query types
- add API for managing filter lists
- update UI to select and create lists
- expose `/filter/[slug].txt` endpoint
- migration for new tables

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686500891a208325a9234be77fc9193e