### PR TITLE
Improve DNS record editing UI

### DIFF
--- a/src/routes/api/records/+server.ts
+++ b/src/routes/api/records/+server.ts
@@ -5,14 +5,16 @@ import { eq } from 'drizzle-orm';
 
 async function getListId(db: ReturnType<typeof getDB>, slug: string) {
 	const [list] = await db.select().from(filterLists).where(eq(filterLists.slug, slug)).all();
-	if (!list) throw new Error('list not found');
-	return list.id as number;
+	return list?.id as number | undefined;
 }
 
 export async function GET({ platform, url }) {
 	const db = getDB(platform);
 	const slug = url.searchParams.get('list') ?? 'default';
 	const listId = await getListId(db, slug);
+	if (!listId) {
+		return json([]);
+	}
 	const records = await db.select().from(dnsRecords).where(eq(dnsRecords.listId, listId)).all();
 	return json(records);
 }
@@ -22,6 +24,9 @@ export async function POST({ request, platform }) {
 	const db = getDB(platform);
 	const slug = data.list ?? 'default';
 	const listId = await getListId(db, slug);
+	if (!listId) {
+		return new Response('list not found', { status: 404 });
+	}
 	await db.insert(dnsRecords).values({
 		name: data.name,
 		type: data.type,
@@ -38,5 +43,19 @@ export async function DELETE({ url, platform }) {
 	}
 	const db = getDB(platform);
 	await db.delete(dnsRecords).where(eq(dnsRecords.id, id)).run();
+	return new Response(null, { status: 200 });
+}
+
+export async function PUT({ request, platform }) {
+	const data = await request.json();
+	if (!data.id) {
+		return new Response('id required', { status: 400 });
+	}
+	const db = getDB(platform);
+	await db
+		.update(dnsRecords)
+		.set({ name: data.name, type: data.type, value: data.value })
+		.where(eq(dnsRecords.id, data.id))
+		.run();
 	return new Response(null, { status: 200 });
 }


### PR DESCRIPTION
## Summary
- support PUT updates for DNS records
- handle missing lists gracefully in record API
- add modal form for creating and editing records with validation
- show edit button in records table

## Testing
- `pnpm run format`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686526eb1cec8325b97f4c33e8e5c874