### PR TITLE
Fix SvelteKit client import issue

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,7 +19,7 @@
 	import RecordModal from '$lib/components/RecordModal.svelte';
 	import type { DNSRecord } from '$lib/server/adblock';
 	import type { InferModel } from 'drizzle-orm';
-	import { filterLists } from '$lib/server/db/schema';
+	import type { filterLists } from '$lib/server/db/schema';
 	let { data } = $props<{
 		data: {
 			lists: InferModel<typeof filterLists>[];


### PR DESCRIPTION
## Summary
- use a type-only import for `filterLists` in `+page.svelte`

## Testing
- `pnpm lint` *(fails: Code style issues found in 9 files)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6865551b3e7c832597794422b21c9da2