### PR TITLE
Use dialog method for modal form

### DIFF
--- a/src/lib/components/RecordModal.svelte
+++ b/src/lib/components/RecordModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { Modal, Button, Label, Input, Select } from 'flowbite-svelte';
-	import { enhance } from '$app/forms';
 	import type { DNSRecord } from '$lib/server/adblock';
 	import { RECORD_TYPES } from '$lib/record-types';
 
@@ -19,19 +18,21 @@
 		type = record.type;
 		value = record.value;
 	}
+	async function recordSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		const form = new FormData(event.target as HTMLFormElement);
+		const res = await fetch('?/saveRecord', { method: 'POST', body: form });
+		if (!res.ok) {
+			error = await res.text();
+			return;
+		}
+		await afterSubmit();
+		open = false;
+	}
 </script>
 
 <Modal bind:open onclose={() => (error = '')}>
-	<form
-		method="POST"
-		action="?/saveRecord"
-		use:enhance={() => {
-			afterSubmit().then(() => {
-				open = false;
-			});
-		}}
-		class="space-y-4"
-	>
+	<form method="dialog" on:submit={recordSubmit} class="space-y-4">
 		{#if record}
 			<input type="hidden" name="id" value={record.id} />
 		{/if}


### PR DESCRIPTION
## Summary
- handle record submit manually in modal form
- use `method="dialog"` in `RecordModal`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68655d53b2ac8325a0bc6f6ed133b3b2