### PR TITLE
Add List creation modal

### DIFF
--- a/src/lib/components/ListModal.svelte
+++ b/src/lib/components/ListModal.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+    import { Modal, Button, Label, Input } from 'flowbite-svelte';
+
+    let {
+        open = $bindable(false),
+        afterSubmit = $bindable(async () => {})
+    } = $props();
+
+    let slug = $state('');
+    let error = $state('');
+
+    async function submit(event: SubmitEvent) {
+        event.preventDefault();
+        const res = await fetch('/api/lists', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ slug })
+        });
+        if (!res.ok) {
+            error = await res.text();
+            return;
+        }
+        slug = '';
+        await afterSubmit();
+        open = false;
+    }
+</script>
+
+<Modal bind:open onclose={() => (error = '')}>
+    <form class="space-y-4" onsubmit={submit}>
+        <div>
+            <Label for="list-slug">List Slug</Label>
+            <Input id="list-slug" bind:value={slug} placeholder="new list slug" />
+        </div>
+        {#if error}
+            <p class="text-red-600">{error}</p>
+        {/if}
+        <div class="flex justify-end gap-2">
+            <Button color="gray" type="button" onclick={() => (open = false)}>Cancel</Button>
+            <Button type="submit">Create List</Button>
+        </div>
+    </form>
+</Modal>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 	import {
-		A,
-		Button,
-		Card,
-		Input,
-		Label,
-		P,
-		Table,
+                A,
+                Button,
+                P,
+                Table,
 		TableBody,
 		TableBodyCell,
 		TableBodyRow,
@@ -16,8 +13,9 @@
 		TabItem
 	} from 'flowbite-svelte';
 	import { EditOutline, TrashBinOutline, CloseOutline, PlusOutline } from 'flowbite-svelte-icons';
-	import RecordModal from '$lib/components/RecordModal.svelte';
-	import type { DNSRecord } from '$lib/server/adblock';
+        import RecordModal from '$lib/components/RecordModal.svelte';
+        import ListModal from '$lib/components/ListModal.svelte';
+        import type { DNSRecord } from '$lib/server/adblock';
 	import type { InferSelectModel } from 'drizzle-orm';
 	import type { filterLists } from '$lib/server/db/schema';
 	let { data } = $props<{
@@ -32,10 +30,10 @@
 	let recordsByList = $state<Record<string, DNSRecord[]>>({
 		[selectedList]: data.records
 	});
-	let newList = $state('');
-	let modalOpen = $state(false);
-	let editing: DNSRecord | null = $state(null);
-	let error = $state('');
+        let modalOpen = $state(false);
+        let listModalOpen = $state(false);
+        let editing: DNSRecord | null = $state(null);
+        let error = $state('');
 
 	function openCreate() {
 		editing = null;
@@ -66,18 +64,7 @@
 		};
 	}
 
-	async function createListSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		const form = new FormData(event.target as HTMLFormElement);
-		const slug = form.get('slug');
-		await fetch('/api/lists', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ slug })
-		});
-		newList = '';
-		await refresh();
-	}
+
 
 	async function loadRecords(slug: string) {
 		if (recordsByList[slug]) return;
@@ -163,29 +150,20 @@
 		</TabItem>
 	{/each}
 
-	<Button
-		class="flex items-center gap-1 rounded px-2 py-1 hover:bg-gray-100"
-		aria-label="Create new list">
-		<PlusOutline class="h-5 w-5 text-green-600" />
-	</Button>
+       <Button
+               class="flex items-center gap-1 rounded px-2 py-1 hover:bg-gray-100"
+               aria-label="Create new list"
+               onclick={() => (listModalOpen = true)}>
+               <PlusOutline class="h-5 w-5 text-green-600" />
+       </Button>
 </Tabs>
 
-<Card class="mx-auto mb-6 max-w-xl">
-	<form class="space-y-4" onsubmit={createListSubmit}>
-		<div>
-			<Label for="list-slug">List Slug</Label>
-			<Input id="list-slug" bind:value={newList} placeholder="new list slug" name="slug" />
-		</div>
-		<div class="text-right">
-			<Button type="submit">Create List</Button>
-		</div>
-	</form>
-</Card>
-
 <RecordModal
-	bind:open={modalOpen}
-	record={editing}
-	list={selectedList}
-	bind:error
-	afterSubmit={refresh}
+        bind:open={modalOpen}
+        record={editing}
+        list={selectedList}
+        bind:error
+        afterSubmit={refresh}
 />
+
+<ListModal bind:open={listModalOpen} afterSubmit={refresh} />


### PR DESCRIPTION
## Summary
- add `ListModal` component to create DNS record lists
- import and use the modal from `+page.svelte`
- open the modal when clicking the new list button
- remove old inline create list form

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68657087a82883258643a0a2069b6dd3