### PR TITLE
Remove R2 bucket storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Everything you need to build a Svelte project, powered by [`sv`](https://github.
 ## DNS record tool
 
 This app stores DNS records in a Cloudflare D1 database and exposes them as
-AdGuard filter rules. Generated rules are written to an R2 bucket. The following
+AdGuard filter rules. The following
 record types are supported:
 
 - `A`, `AAAA`, `CNAME`, `HTTPS`, `MX`, `PTR`, `SRV`, and `TXT`.
@@ -77,4 +77,4 @@ pnpm install
 pnpm run dev
 ```
 
-Configure Cloudflare D1 and R2 bindings as shown in `wrangler.jsonc` before using `wrangler dev` or deploying.
+Configure Cloudflare D1 bindings as shown in `wrangler.jsonc` before using `wrangler dev` or deploying.

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,17 +1,11 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
-import type {
-	R2Bucket,
-	D1Database,
-	CfProperties,
-	ExecutionContext
-} from '@cloudflare/workers-types';
+import type { D1Database, CfProperties, ExecutionContext } from '@cloudflare/workers-types';
 
 declare global {
 	namespace App {
 		interface Platform {
 			env?: {
-				BUCKET: R2Bucket;
 				DB: D1Database;
 				RUN_MIGRATIONS?: string;
 			};

--- a/src/routes/filter.txt/+server.ts
+++ b/src/routes/filter.txt/+server.ts
@@ -10,7 +10,6 @@ export const GET: RequestHandler = async ({ platform }) => {
 	if (!list) return new Response('list not found', { status: 404 });
 	const records = await db.select().from(dnsRecords).where(eq(dnsRecords.listId, list.id)).all();
 	const content = generateFilter(records);
-	await platform?.env?.BUCKET.put('filter.txt', content);
 	return new Response(content, {
 		headers: { 'content-type': 'text/plain' }
 	});

--- a/src/routes/filter/[slug].txt/+server.ts
+++ b/src/routes/filter/[slug].txt/+server.ts
@@ -12,7 +12,6 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 	}
 	const records = await db.select().from(dnsRecords).where(eq(dnsRecords.listId, list.id)).all();
 	const content = generateFilter(records);
-	await platform?.env?.BUCKET.put(`filter-${params.slug}.txt`, content);
 	return new Response(content, {
 		headers: { 'content-type': 'text/plain' }
 	});

--- a/src/worker-configuration.d.ts
+++ b/src/worker-configuration.d.ts
@@ -3,7 +3,6 @@
 // Runtime types generated with workerd@1.20250617.0 2025-06-13 nodejs_compat
 declare namespace Cloudflare {
 	interface Env {
-		BUCKET: R2Bucket;
 		DB: D1Database;
 		ASSETS: Fetcher;
 	}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,13 +23,8 @@
 			"database_id": "d7dcfbe5-522b-4bf8-80e2-a45546184c95",
 			"migrations_dir": "drizzle/migrations"
 		}
-	],
-	"r2_buckets": [
-		{
-			"binding": "BUCKET",
-			"bucket_name": "agh-rules"
-		}
 	]
+
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
## Summary
- drop R2 bucket usage from endpoints and env types
- remove R2 binding from wrangler config
- update README accordingly

## Testing
- `pnpm test`
- `pnpm lint` *(fails: NavBar unused vars and worker-configuration warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6865f9a022088325ab730b7dd0973d6c