### PR TITLE
Fix duplicate slug handling

### DIFF
--- a/src/routes/api/lists/+server.ts
+++ b/src/routes/api/lists/+server.ts
@@ -31,6 +31,14 @@ export async function POST({ request, platform }) {
 		return new Response('slug required', { status: 400 });
 	}
 	const db = getDB(platform);
+	const [existing] = await db
+		.select()
+		.from(filterLists)
+		.where(eq(filterLists.slug, data.slug))
+		.all();
+	if (existing) {
+		return new Response('duplicate slug', { status: 409 });
+	}
 	await db.insert(filterLists).values({ slug: data.slug });
 	return new Response(null, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- prevent duplicate list slugs from throwing an error by returning 409

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6871f9bb30b48325a175d19e6e7793b0